### PR TITLE
#8 Javaにおける開発環境

### DIFF
--- a/ObjectOriented_Programming/Java/.env
+++ b/ObjectOriented_Programming/Java/.env
@@ -1,0 +1,9 @@
+export JAVA_HOME=/usr/local/lib/jdk-16.0.1
+
+export _JAVA_OPTION="-Dfile.encoding=UTF-8"
+export ANT_HOME="/usr/local/lib/ant"
+export ANT_OPTS="-Dfile.encoding=UTF-8 -Xmx512m -Xss256k"
+
+# PATH=$PATH:$ANT_HOME/bin
+
+# PATH=$PATH:$JAVA_HOME/bin

--- a/ObjectOriented_Programming/Java/Dockerfile
+++ b/ObjectOriented_Programming/Java/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:18.04
+
+RUN \
+    apt-get update && \
+    apt-get -y upgrade && \
+    apt-get install -y \
+    apt-utils \
+    git \
+    g++ \
+    make \
+    cmake \
+    curl \
+    vim
+
+RUN curl -S -o /tmp/openjdk-16.0.1_linux-aarch64_bin.tar.gz https://download.java.net/java/GA/jdk16.0.1/7147401fd7354114ac51ef3e1328291f/9/GPL/openjdk-16.0.1_linux-aarch64_bin.tar.gz -# && \
+    tar -C /usr/local/lib -xvf /tmp/openjdk-16.0.1_linux-aarch64_bin.tar.gz && \
+    rm /tmp/openjdk-16.0.1_linux-aarch64_bin.tar.gz
+    
+RUN curl -S -o /tmp/apache-ant-1.10.10-bin.tar.gz https://ftp.kddi-research.jp/infosystems/apache//ant/binaries/apache-ant-1.10.10-bin.tar.gz -# && \
+    tar -C /usr/local/ -xvf /tmp/apache-ant-1.10.10-bin.tar.gz && \
+    rm /tmp/apache-ant-1.10.10-bin.tar.gz && \
+    rm -f /usr/local/lib/ant && \
+    ln -s /usr/local/apache-ant-1.10.10 /usr/local/lib/ant

--- a/ObjectOriented_Programming/Java/docker-compose.yml
+++ b/ObjectOriented_Programming/Java/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services: 
+    java: 
+        build: 
+            dockerfile: ./Dockerfile
+            context: .
+        volumes: 
+            - .:/Java/
+        env_file: 
+            - ./.env
+        stdin_open: true
+        tty: true


### PR DESCRIPTION
# 概要
issues #8 対応

# 内容
JavaにおけるDockerを用いた環境開発
- OpenJDK-16.0.1
- Apache Ant-1.10.10

# 現在の状態と不具合
- 現在問題なく動作している。
- はじめに.env内にてコメントアウトされているPATHを通す部分のコマンドのみ手動で入力する必要がある。